### PR TITLE
The included gems require ruby version 2.0 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,4 @@ env:
   - PUPPET_VERSION="~> 3.4.0"
 notifications:
   email:
-    - javier@netmanagers.com.ar
-
-
-
+    - sre@procore.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
 ---
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
 script: bundle exec rake spec
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 2.7.0"
 notifications:
   email:
     - javier@netmanagers.com.ar


### PR DESCRIPTION
https://github.com/procore/puppet-dnsmasq/issues/5

It looks like the builds for 1.8.7 and 1.9.3 ruby versions are failing because of gem dependencies that require 2.0 or higher.