### PR TITLE
Support and test Puppet 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 4.7.0"
 notifications:
   email:
     - sre@procore.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - |
-    PUPPET_VERSION="~> 4.7.0"
+    PUPPET_VERSION="~> 4.8.1"
     STRICT_VARIABLES=no
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 4.7.0"
+  - |
+    PUPPET_VERSION="~> 4.7.0"
+    STRICT_VARIABLES=no
 notifications:
   email:
     - sre@procore.com

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem "rake"
 gem "puppet", ENV['PUPPET_VERSION'] || '~> 2.7.0'
 gem "puppet-lint"
-gem "rspec-puppet", '~> 1.0.0'
+gem "rspec-puppet"
 gem "puppet-syntax"
 gem "puppetlabs_spec_helper"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -861,7 +861,7 @@ class dnsmasq (
   }
 
   # The whole dnsmasq configuration directory can be recursively overriden
-  if $dnsmasq::source_dir {
+  if $source_dir != '' {
     file { 'dnsmasq.dir':
       ensure  => directory,
       path    => $dnsmasq::config_dir,

--- a/spec/classes/dnsmasq_spec.rb
+++ b/spec/classes/dnsmasq_spec.rb
@@ -4,7 +4,7 @@ describe 'dnsmasq' do
 
   let(:title) { 'dnsmasq' }
   let(:node) { 'rspec.example42.com' }
-  let(:facts) { { :ipaddress => '10.42.42.42',:concat_basedir => '/var/lib/puppet/concat'} }
+  let(:facts) { { :ipaddress => '10.42.42.42',:concat_basedir => '/var/lib/puppet/concat', operatingsystemrelease: '14.04' } }
 
   describe 'Test standard installation' do
     it { should contain_package('dnsmasq').with_ensure('present') }
@@ -91,6 +91,12 @@ describe 'dnsmasq' do
     it { should contain_file('dnsmasq.dir').with_force('true') }
   end
 
+  describe 'Test customizations - empty source_dir' do
+    let(:params) { {:source_dir => "" , :source_dir_purge => true } }
+    it { should_not contain_file('dnsmasq.dir').with_source('puppet:///modules/dnsmasq/dir/spec') }
+    it { should_not contain_file('dnsmasq.dir').with_purge('true') }
+    it { should_not contain_file('dnsmasq.dir').with_force('true') }
+  end
   describe 'Test customizations - custom class' do
     let(:params) { {:my_class => "dnsmasq::spec" } }
     it { should contain_file('dnsmasq.conf').with_content(/rspec.example42.com/) }


### PR DESCRIPTION
So far the only Puppet 4 breakage I've seen is that it treats empty strings as truthy, leading to some unintended behavior. 