### PR TITLE
Add .ruby-version and Gemfile.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Session.vim
 spec/fixtures
 .*.sw[a-z]
 *.un~
+Gemfile.lock
+.ruby-version


### PR DESCRIPTION
If we don't want to commit a ruby-version or Gemfile.lock, then let's
gitignore those files so people can still use them without working
around them when committing.