### PR TITLE
Default the puppet version to 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rake"
-gem "puppet", ENV['PUPPET_VERSION'] || '~> 2.7.0'
+gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.2.0'
 gem "puppet-lint"
 gem "rspec-puppet", '~> 1.0.0'
 gem "puppet-syntax"


### PR DESCRIPTION
Since we dropped support for Puppet 2.X, the Gemfile should default to
our lowest supported Puppet version, which is 3.2 right now